### PR TITLE
[tests] update categories test to accept popup on delete

### DIFF
--- a/tests/acceptance/administrator/AdministratorCategoriesCest.php
+++ b/tests/acceptance/administrator/AdministratorCategoriesCest.php
@@ -168,6 +168,7 @@ class AdministratorCategoriesCest
 		$I->checkAllResults();
 		$I->amGoingTo('try to delete a Weblinks Category');
 		$I->clickToolbarButton('Empty trash');
+		$I->acceptPopup();
 		$I->waitForElement(['id' => 'system-message-container'], '60');
 		$I->expectTo('see a success message after Deleting the category');
 		$I->see('1 category successfully deleted.', ['id' => 'system-message-container']);


### PR DESCRIPTION
This pull fixes the tests failing by accepting the new popup when deleting a category:

![screen shot 2016-02-01 at 10 26 00](https://cloud.githubusercontent.com/assets/1375475/12713400/a2d9e2a4-c8ce-11e5-965a-71c5865ea596.png)

please @infograf768 accept my pull so the tests run again in travis.

note that the new popup only appears when deleting a `category`. For consistency I suggest that we add the same feature when removing a `weblink`.
